### PR TITLE
Add testcase for end_sequence having offset past retq

### DIFF
--- a/tests/all/debug/translate.rs
+++ b/tests/all/debug/translate.rs
@@ -24,6 +24,25 @@ fn check_wasm(wasm_path: &str, directives: &str) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
+fn check_line_program(wasm_path: &str, directives: &str) -> Result<()> {
+    let wasm = read(wasm_path)?;
+    let obj_file = NamedTempFile::new()?;
+    let obj_path = obj_file.path().to_str().unwrap();
+    compile_cranelift(&wasm, None, obj_path)?;
+    let dump = get_dwarfdump(obj_path, DwarfDumpSection::DebugLine)?;
+    let mut builder = CheckerBuilder::new();
+    builder
+        .text(directives)
+        .map_err(|e| format_err!("unable to build checker: {:?}", e))?;
+    let checker = builder.finish();
+    let check = checker
+        .explain(&dump, NO_VARIABLES)
+        .map_err(|e| format_err!("{:?}", e))?;
+    assert!(check.0, "didn't pass check {}", check.1);
+    Ok(())
+}
+
 #[test]
 #[ignore]
 #[cfg(all(
@@ -86,6 +105,26 @@ check:        DW_AT_name	("b")
 check:      DW_TAG_variable
 check:        DW_AT_name	("i")
 check:        DW_AT_decl_line	(10)
+    "##,
+    )
+}
+
+#[test]
+#[ignore]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    target_arch = "x86_64",
+    target_pointer_width = "64"
+))]
+fn test_debug_dwarf5_translate_lines() -> Result<()> {
+    check_line_program(
+        "tests/all/debug/testsuite/fib-wasm-dwarf5.wasm",
+        r##"
+check:   Address            Line   Column File   ISA Discriminator Flags
+check: 0x000000000000013c     15      3      1   0             0
+# The important point is that the following offset must be _after_ the `ret` instruction.
+# FIXME: this +1 increment might vary on other archs.
+check: 0x000000000000013d     15      3      1   0             0  end_sequence
     "##,
     )
 }


### PR DESCRIPTION
Add test case for x86_64 arch

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
